### PR TITLE
list.c - fix for use of sizeof() on a pointer type in hash_func

### DIFF
--- a/src/openvpn/list.c
+++ b/src/openvpn/list.c
@@ -225,7 +225,7 @@ hash_remove_marked(struct hash *hash, struct hash_bucket *bucket)
 uint32_t
 void_ptr_hash_function(const void *key, uint32_t iv)
 {
-    return hash_func((const void *)&key, sizeof(key), iv);
+    return hash_func((const void *)&key, sizeof(*key), iv);
 }
 
 bool


### PR DESCRIPTION
fix will ensure sizeof() returns the size of the data structure itself, and not the size of the pointer to the data structure. (CWE-467).

# Thank you for your contribution

You are welcome to open PR, but they are used for discussion only. All
patches must eventually go to the openvpn-devel mailing list for review:

* https://lists.sourceforge.net/lists/listinfo/openvpn-devel

Please send your patch using [git-send-email](https://git-scm.com/docs/git-send-email). For example to send your latest commit to the list:

    $ git send-email --to=openvpn-devel@lists.sourceforge.net HEAD~1

For details, see these Wiki articles:

* https://community.openvpn.net/openvpn/wiki/DeveloperDocumentation
* https://community.openvpn.net/openvpn/wiki/Contributing
